### PR TITLE
Issue: Change the hardcoded vidi url in Request.php to use the vidiUrl param instead

### DIFF
--- a/api/Request.php
+++ b/api/Request.php
@@ -8,6 +8,7 @@
 
 namespace app\extensions\vidi_cookie_getter\api;
 
+use app\conf\App;
 use app\inc\Controller;
 use app\inc\Input;
 use Exception;
@@ -39,7 +40,7 @@ class Request extends Controller
         ];
 
         try {
-            $client->post("http://vidi:3000/api/session/start", [
+            $client->post(App::$param["vidiUrl"] . "/api/session/start", [
                 'headers' => array('Content-Type' => 'application/json'),
                 'json' => $input]);
             $cookieJar = $client->getConfig('cookies');


### PR DESCRIPTION
Instead of using the internal docker dns in Request.php it's now using the vidiUrl from param.